### PR TITLE
Specify the public hostname via $PUBLIC_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-RUN apt-get update && \
-  apt-get install -y curl && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/
-
 COPY files/entrypoint.sh /bin/entrypoint.sh
 
 ARG GIT_COMMIT_SHA

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -12,13 +12,10 @@ if [[ "${ENABLE_SDM_GATEWAY}" == "false" ]] ; then \
   export SDM_RELAY_TOKEN=`$CMD relay create`
 fi
 
-# if we're a gateway, get our public ip and then create a gateway token
+# If we're a gateway, get our public ip and then create a gateway token
 if [[ "${ENABLE_SDM_GATEWAY}" == "true" ]] ; then \
-  CURL_METADATA_COMMAND="curl --silent --max-time ${CURL_METADATA_TIMEOUT} http://169.254.169.254/latest/meta-data/public-ipv4"
-  echo $CURL_METADATA_COMMAND
-  PUBLIC_IP=$(eval "$CURL_METADATA_COMMAND")
-  echo "found public IP $PUBLIC_IP"
-  CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway ${PUBLIC_IP}:${SDM_GATEWAY_LISTEN_APP_PORT} 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT}"
+  echo "found public host $PUBLIC_HOST"
+  CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway ${PUBLIC_HOST}:${SDM_GATEWAY_LISTEN_APP_PORT} 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT}"
   echo "running: $CREATE_GATEWAY_TOKEN_COMMAND"
   export SDM_RELAY_TOKEN=$(eval "$CREATE_GATEWAY_TOKEN_COMMAND")
 fi


### PR DESCRIPTION
The previous technique (`curl`-ing the metadata IP) breaks down when using a Fargate container, which can’t run using bridge networking and thus must use an LB to receive traffic.