### PR TITLE
Bump default task log retention to 365 days

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -84,8 +84,8 @@ variable "extra_task_policy_arns" {
 }
 
 variable "ecs_log_retention" {
-  description = "Number of days of ECS task logs to retain (default 3)"
-  default     = 3
+  description = "Number of days of ECS task logs to retain (default 365)"
+  default     = 365
 }
 
 variable "sdm_gateway_listen_app_port" {


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope

### What ticket(s) or other PRs does this relate to?
https://app.clubhouse.io/highwing/story/155/take-a-pass-to-add-encryption-retention-settings-to-all-existing-log-groups-appsync-lambdas-etc

### What was the problem or feature?
Our log retention for SDM gateways was only three days

### What was the solution?
Bump it to 365 for SOC2 reasons


### Where does this work fall on the Good - Fast spectrum?
💨 

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to bump the module version in the main `lambdas` repo once this is merged/released.
