### PR TITLE
Adjust LB type to application to support SGs

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "inbound_nlb_traffic" {
 resource "aws_lb" "nlb" {
   name               = local.name_prefix
   internal           = false #tfsec:ignore:AWS005
-  load_balancer_type = "network"
+  load_balancer_type = "application"
   subnets            = var.public_subnet_ids
   security_groups    = [aws_security_group.inbound_nlb_traffic.id]
 }


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope

### What ticket(s) or other PRs does this relate to?
https://github.com/highwingio/terraform-aws-strongdm/pull/5/files

### What was the problem or feature?
It's not possible to assign security groups to network load balancers.

### What was the solution?
Switch to an application load balancer

- [x] Security Impact has been considered: No changes.
- [x] Network Impacts have been considered: Different appliance, but they should be largely equivalent for this use case.

### Where does this work fall on the Good - Fast spectrum?
💨 

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to update usage of this one downstream (again).